### PR TITLE
Build quality-of-life

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 *.out
 *.rcb
 *.wav
-
+flodplayer
+config.mak

--- a/Makefile
+++ b/Makefile
@@ -70,10 +70,10 @@ clean:
 	$(CC) $(CFLAGS) $(INC) -c -o $@ $<
 
 flodplayer: $(OBJS)
-	$(CC) $(LDFLAGS) -o $@ $(OBJS) -lm -lao
+	$(CC) -o $@ $(OBJS) -lm -lao $(LDFLAGS)
 
 flod_demo.out: $(OBJS)
-	$(CC) $(LDFLAGS)-o $@ $(OBJS) -lm -lao
+	$(CC) -o $@ $(OBJS) -lm -lao $(LDFLAGS)
 
 libflod.a: $(OBJS)
 	rm -f $@


### PR DESCRIPTION
Just git-ignoring some files, and making `LDFLAGS` positioning canonical (It should be at the end; it will work for some compilers at the start, but will break for others).

Additionally I think it should be documented that you can get it to build on Linux, and mingw or Cygwin as well, by using the following `config.mak`:

```makefile
CFLAGS+= $(shell sdl2-config --cflags)
LDFLAGS+= $(shell sdl2-config --libs)
```